### PR TITLE
modified the "Email Us" and "Call Us" sections into buttons

### DIFF
--- a/Contact.html
+++ b/Contact.html
@@ -52,6 +52,7 @@
       border-radius: 25px;
       font-size: 1.1rem;
       transition: background-color 0.3s;
+      text-decoration: none;
     }
 
     .contact-btn:hover {
@@ -63,18 +64,24 @@
       padding: 15px;
       border-radius: 10px;
       margin-bottom: 30px;
+      text-align: center;
+    }
+
+    .info-box a {
+      text-decoration: none;
+      color: #fff;
+      font-size: 1.1rem;
+    }
+
+    .info-box a:hover {
+      text-decoration: none;
     }
 
     .info-box h5 {
       font-size: 1.2rem;
       font-weight: 600;
-      margin-bottom: 5px;
+      margin-bottom: 15px;
       color: var(--pistachio);
-    }
-
-    .info-box p {
-      margin-bottom: 0;
-      font-size: 1rem;
     }
   </style>
 </head>
@@ -94,12 +101,12 @@
         <!-- Contact Information -->
         <div class="info-box">
           <h5>Email Us</h5>
-          <p>support@wildguard.com</p>
+          <a href="mailto:support@wildguard.com" class="btn contact-btn">Email Us</a>
         </div>
 
         <div class="info-box">
           <h5>Call Us</h5>
-          <p>+91 123-4567-089</p>
+          <a href="tel:+911234567089" class="btn contact-btn">Call Us</a>
         </div>
 
         <!-- Contact Form -->


### PR DESCRIPTION
Key Changes:
Clickable Buttons for Email and Phone:

Wrapped the "Email Us" and "Call Us" content inside <a> tags and used mailto: and tel: links to make them clickable. Applied the .contact-btn class to these links to make them look like buttons. Styling Adjustments:

Modified the button hover effect to ensure a consistent look for the new buttons. Now, the "Email Us" and "Call Us" sections will behave like buttons, allowing users to directly email or call with one click.